### PR TITLE
fix: enabling debug should be done before starting up the agent

### DIFF
--- a/bootstrap/src/main/java/io/lumigo/javaagent/LumigoAgent.java
+++ b/bootstrap/src/main/java/io/lumigo/javaagent/LumigoAgent.java
@@ -26,6 +26,12 @@ public class LumigoAgent {
   }
 
   public static void agentmain(final String agentArgs, final Instrumentation inst) {
+    if (isDebugMode()) {
+      System.setProperty("otel.javaagent.debug", "true");
+      System.setProperty("io.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel", "debug");
+      System.setProperty("otel.log.level", "debug");
+      System.setProperty("lumigo.debug", "true");
+    }
     if (is_switch_off()) {
       return;
     }

--- a/custom/src/main/java/io/lumigo/javaagent/LumigoConfigurator.java
+++ b/custom/src/main/java/io/lumigo/javaagent/LumigoConfigurator.java
@@ -64,9 +64,8 @@ public class LumigoConfigurator implements AutoConfigurationCustomizerProvider {
         debugSpanDump = "/dev/stdout";
       }
       try {
-        tracerProvider =
-            tracerProvider.addSpanProcessor(
-                SimpleSpanProcessor.create(FileLoggingSpanExporter.create(debugSpanDump)));
+        tracerProvider.addSpanProcessor(
+            SimpleSpanProcessor.create(FileLoggingSpanExporter.create(debugSpanDump)));
 
       } catch (IOException e) {
         throw new RuntimeException("Failed to create file handler for " + debugSpanDump, e);
@@ -83,8 +82,12 @@ public class LumigoConfigurator implements AutoConfigurationCustomizerProvider {
     if (accessToken == null || accessToken.isEmpty()) {
       logger.warning("Lumigo Tracer Token is not set. Tracing is disabled.");
     } else {
-      String rawHeaders = cfg.getString("otel.exporter.otlp.headers", "");
-      List<String> headers = new ArrayList<>(Arrays.asList(rawHeaders.split(",")));
+      List<String> headers = new ArrayList<>();
+
+      String rawHeaders = cfg.getString("otel.exporter.otlp.headers");
+      if (rawHeaders != null) {
+        headers = new ArrayList<>(Arrays.asList(rawHeaders.split(",")));
+      }
 
       headers.add("Authorization=LumigoToken " + accessToken);
 
@@ -94,12 +97,6 @@ public class LumigoConfigurator implements AutoConfigurationCustomizerProvider {
       // testing)
       upsert(customized, cfg, "otel.exporter.otlp.endpoint", LUMIGO_ENDPOINT_URL);
       upsert(customized, cfg, "otel.exporter.otlp.protocol", "http/protobuf");
-    }
-
-    if (cfg.getBoolean(LUMIGO_DEBUG, false)) {
-      customized.put("otel.javaagent.debug", "true");
-      System.setProperty("io.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel", "debug");
-      customized.put("otel.log.level", "debug");
     }
 
     return customized;

--- a/custom/src/main/java/io/lumigo/javaagent/LumigoConfigurator.java
+++ b/custom/src/main/java/io/lumigo/javaagent/LumigoConfigurator.java
@@ -86,7 +86,7 @@ public class LumigoConfigurator implements AutoConfigurationCustomizerProvider {
 
       String rawHeaders = cfg.getString("otel.exporter.otlp.headers");
       if (rawHeaders != null) {
-        headers = new ArrayList<>(Arrays.asList(rawHeaders.split(",")));
+        headers.addAll(Arrays.asList(rawHeaders.split(",")));
       }
 
       headers.add("Authorization=LumigoToken " + accessToken);

--- a/smoke-tests/src/test/java/io/lumigo/javaagent/smoketest/SmokeTest.java
+++ b/smoke-tests/src/test/java/io/lumigo/javaagent/smoketest/SmokeTest.java
@@ -100,11 +100,12 @@ abstract class SmokeTest {
             .withEnv("OTEL_BSP_SCHEDULE_DELAY", "10ms")
             .withEnv("LUMIGO_TRACER_TOKEN", "test-123")
             .withEnv("LUMIGO_DEBUG_SPANDUMP", SPANDUMP_FILE)
+            .withEnv("LUMIGO_DEBUG", "true")
             .withEnv(getExtraEnv());
     target.start();
   }
 
-  String fetchSpanDumpFromTarget() {
+  protected String fetchSpanDumpFromTarget() {
     try {
       Path temp = Files.createTempFile("spandump", ".log");
       target.copyFileFromContainer(SPANDUMP_FILE, temp.toString());

--- a/smoke-tests/src/test/java/io/lumigo/javaagent/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/io/lumigo/javaagent/smoketest/SpringBootSmokeTest.java
@@ -39,6 +39,11 @@ class SpringBootSmokeTest extends SmokeTest {
   @Test
   public void springBootSmokeTestOnJDK() throws IOException, InterruptedException {
     startTarget(8);
+
+    // check if the debug log is printed
+    Assertions.assertTrue(
+        target.getLogs().contains("DEBUG io.opentelemetry.javaagent.tooling.AgentInstaller"));
+
     String url = String.format("http://localhost:%d/greeting", target.getMappedPort(8080));
     Request request = new Request.Builder().url(url).get().build();
 


### PR DESCRIPTION
This change fixes the `LUMIGO_DEBUG` flag by setting it in the `premain`.

closes #6 