### PR TITLE
feat: Sampler for filtering HTTP server endpoints. By default it excludes `.*/health.*` and `.*/actuator.*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The Lumigo OpenTelemetry Distro for Java additionally supports the following con
 * `LUMIGO_SECRET_MASKING_REGEX='["regex1", "regex2"]'`: Prevents Lumigo from sending keys that match the supplied regular expressions in process environment data. All regular expressions are case-insensitive. The "magic" value `all` will redact everything. By default, Lumigo applies the following regular expressions: `[".*pass.*", ".*key.*", ".*secret.*", ".*credential.*", ".*passphrase.*"]`. More fine-grained settings can be applied via the following environment variable, which will override `LUMIGO_SECRET_MASKING_REGEX` for a specific type of data:
   * `LUMIGO_SECRET_MASKING_REGEX_ENVIRONMENT` applies secret redaction to process environment variables (that is, the content of `System.getenv()`)
 * `LUMIGO_TAG=<value>`: Adds the tag value as an attribute to all spans; this is useful to identify the source of the telemetry in Lumigo. See [here](https://docs.lumigo.io/docs/tags) for details.
+* `LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX='["regex1", "regex2"]'`: This option enables the automatic filtering of server endpoints that match the supplied regular expressions. By default, this distribution applies the following regular expressions: `[".*/health.*", ".*/actuator.*"]`. Refer to the
+[Filtering out HTTP endpoints](#filtering-out-http-endpoints) section for details.
 
 For more configuration options, see the [Upstream Agent Configuration](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/).
 
@@ -185,6 +187,19 @@ Attributes eventAttributes = Attributes.of(
 
 Span.current().addEvent("<error-message>", eventAttributes);
 ```
+
+### Filtering out HTTP endpoints
+
+It is possible to automatically filter out spans based on an HTTP servers endpoints for all supported web server frameworks.
+
+Set the `LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX` environment variable to a regex string matching all desired urls to be filtered out.
+Spans with urls matching the filter will be not be delivered (works for both incoming & outgoing HTTP requests).
+Matching is performed against the following attributes of a span: `url.full`, `url.path`, `http.target`[^1], and `http.url`[^2].
+
+[^1] The `http.target` attribute in the Trace HTTP Semantic Conventions is deprecated and replaced by `url.path`.
+[^2] The `http.url` attribute in the Trace HTTP Semantic Conventions is deprecated and replaced by `url.full`.
+
+When filtering out spans, any child spans created from that component will also be filtered out as they will not be recorded.
 
 ## Supported runtimes
 

--- a/bootstrap/src/main/java/io/lumigo/instrumentation/core/AbstractBufferHolder.java
+++ b/bootstrap/src/main/java/io/lumigo/instrumentation/core/AbstractBufferHolder.java
@@ -51,9 +51,7 @@ public abstract class AbstractBufferHolder {
     try {
       final String requestBody = getBufferAsString(charsetName);
       if (requestBody != null && !requestBody.isEmpty()) {
-        System.out.println("BEFORE SETTING REQUEST BODY ATTRIBUTE");
         span.setAttribute(SemanticAttributes.HTTP_REQUEST_BODY, requestBody);
-        System.out.println("AFTER SETTING REQUEST BODY ATTRIBUTE");
       }
     } catch (UnsupportedEncodingException ignored) {
       // Ignore error, it shouldn't occur as we've previously parsed the charset for validity
@@ -69,9 +67,7 @@ public abstract class AbstractBufferHolder {
     try {
       final String responseBody = getBufferAsString(charsetName);
       if (responseBody != null && !responseBody.isEmpty()) {
-        System.out.println("BEFORE SETTING RESPONSE BODY ATTRIBUTE");
         currentSpan.setAttribute(SemanticAttributes.HTTP_RESPONSE_BODY, responseBody);
-        System.out.println("AFTER SETTING RESPONSE BODY ATTRIBUTE");
       }
     } catch (UnsupportedEncodingException ignored) {
       // Ignore error, it shouldn't occur as we've previously parsed the charset for validity

--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -21,6 +21,13 @@ dependencies {
     exclude group: "io.opentelemetry", module: "opentelemetry-sdk-extension-autoconfigure"
   }
 
+  implementation("io.opentelemetry.contrib:opentelemetry-samplers:${versions.opentelemetryContrib}") {
+    exclude group: "io.opentelemetry", module: "opentelemetry-sdk"
+    exclude group: "io.opentelemetry", module: "opentelemetry-api"
+    exclude group: "io.opentelemetry", module: "opentelemetry-semconv"
+    exclude group: "io.opentelemetry", module: "opentelemetry-sdk-extension-autoconfigure"
+  }
+
   annotationProcessor deps.autoservice
   compileOnly deps.autoservice
 

--- a/custom/src/main/java/io/lumigo/javaagent/common/AbstractRegExParser.java
+++ b/custom/src/main/java/io/lumigo/javaagent/common/AbstractRegExParser.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Lumigo LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.lumigo.javaagent.common;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import io.lumigo.javaagent.utils.Strings;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+abstract class AbstractRegExParser {
+  private static final Logger LOGGER = Logger.getLogger(AbstractRegExParser.class.getName());
+
+  private static final String NO_MAGIC_VALUE = "NO_MAGIC_VALUE";
+
+  protected static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+  protected abstract String getEnvVarName();
+
+  protected abstract List<String> getDefaultRegexKeys();
+
+  protected String getMagicValue() {
+    return NO_MAGIC_VALUE;
+  }
+
+  private String getWarningMessage() {
+    if (NO_MAGIC_VALUE.equals(getMagicValue())) {
+      return "it must be a stringified JSON array of regular expressions, e.g.: '[\"a.*\",\"b.*\"]'";
+    } else {
+      return "it must either be "
+          + getMagicValue()
+          + " or a stringified JSON array of regular expressions, e.g.: '[\"a.*\",\"b.*\"]'";
+    }
+  }
+
+  public ParseExpressionResult parseExpressions(ConfigProperties config, String overrideEnvName) {
+    final String sourceEnvVar;
+    if (!Strings.isBlank(overrideEnvName) && !Strings.isBlank(config.getString(overrideEnvName))) {
+      sourceEnvVar = overrideEnvName;
+    } else if (!Strings.isBlank(config.getString(getEnvVarName()))) {
+      sourceEnvVar = getEnvVarName();
+    } else {
+      sourceEnvVar = "";
+    }
+
+    final String regExps = !sourceEnvVar.isEmpty() ? config.getString(sourceEnvVar) : "";
+    assert regExps != null;
+    if (regExps.equalsIgnoreCase(getMagicValue())) {
+      return new ParseExpressionResult(sourceEnvVar, regExps);
+    }
+
+    final List<Pattern> patterns;
+    if (!Strings.isBlank(regExps)) {
+      patterns = new ArrayList<>();
+      try (JsonParser parser = JSON_FACTORY.createParser(regExps)) {
+        if (!JsonToken.START_ARRAY.equals(parser.nextToken())) {
+          throw new IllegalArgumentException();
+        }
+        while (!JsonToken.END_ARRAY.equals(parser.nextToken())) {
+          if (parser.currentToken().equals(JsonToken.VALUE_STRING)) {
+            patterns.add(Pattern.compile(parser.getText(), Pattern.CASE_INSENSITIVE));
+          } else {
+            throw new IllegalArgumentException();
+          }
+        }
+        return new ParseExpressionResult(sourceEnvVar, regExps, patterns);
+      } catch (Exception e) {
+        LOGGER.warning(
+            "Failed to parse the regex: "
+                + regExps
+                + " set in the "
+                + sourceEnvVar
+                + " environment variable; "
+                + getWarningMessage()
+                + " Falling back to default: "
+                + getDefaultRegexKeys());
+      }
+    }
+    return new ParseExpressionResult(
+        sourceEnvVar,
+        regExps,
+        getDefaultRegexKeys().stream()
+            .map(exp -> Pattern.compile(exp, Pattern.CASE_INSENSITIVE))
+            .collect(Collectors.toList()));
+  }
+}

--- a/custom/src/main/java/io/lumigo/javaagent/common/HttpEndpointFilter.java
+++ b/custom/src/main/java/io/lumigo/javaagent/common/HttpEndpointFilter.java
@@ -20,38 +20,20 @@ package io.lumigo.javaagent.common;
 import java.util.Arrays;
 import java.util.List;
 
-public abstract class SecretScrubber extends AbstractRegExParser {
-  public static final int DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT = 2048;
-  public static final String LUMIGO_SECRET_MASKING_REGEX = "lumigo.secret.masking.regex";
-  public static final String LUMIGO_SECRET_MASKING_ALL_MAGIC = "all";
-  public static final String SCRUBBED_VALUE = "****";
+public class HttpEndpointFilter extends AbstractRegExParser {
+  public static final String LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX =
+      "lumigo.auto.filter.http.endpoints.regex";
 
   public static final List<String> DEFAULT_REGEX_KEYS =
-      Arrays.asList(
-          ".*pass.*",
-          ".*key.*",
-          ".*secret.*",
-          ".*credential.*",
-          ".*passphrase.*",
-          ".*token.*",
-          "SessionToken",
-          "x-amz-security-token",
-          "Signature",
-          "Credential",
-          "Authorization");
+      Arrays.asList(".*/health.*", ".*/actuator.*");
 
   @Override
   protected String getEnvVarName() {
-    return LUMIGO_SECRET_MASKING_REGEX;
+    return LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX;
   }
 
   @Override
   protected List<String> getDefaultRegexKeys() {
     return DEFAULT_REGEX_KEYS;
-  }
-
-  @Override
-  protected String getMagicValue() {
-    return LUMIGO_SECRET_MASKING_ALL_MAGIC;
   }
 }

--- a/custom/src/test/java/io/lumigo/javaagent/common/HttpEndpointFilterTest.java
+++ b/custom/src/test/java/io/lumigo/javaagent/common/HttpEndpointFilterTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023 Lumigo LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.lumigo.javaagent.common;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import org.junit.jupiter.api.Test;
+
+class HttpEndpointFilterTest {
+  @Test
+  void testDefaults() {
+    ConfigProperties mockConfig = mock();
+
+    HttpEndpointFilter filter = new HttpEndpointFilter();
+    ParseExpressionResult result = filter.parseExpressions(mockConfig, null);
+
+    assertThat(result.getExpressionPatterns().size(), equalTo(2));
+    assertThat(result.getExpressionPatterns().get(0).pattern(), equalTo(".*/health.*"));
+    assertThat(result.getExpressionPatterns().get(1).pattern(), equalTo(".*/actuator.*"));
+    assertThat(result.getRegularExpressions(), equalTo(""));
+  }
+
+  @Test
+  void testEmptyHttpFilter() {
+    ConfigProperties mockConfig = mock();
+    when(mockConfig.getString(HttpEndpointFilter.LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX))
+        .thenReturn("");
+
+    HttpEndpointFilter filter = new HttpEndpointFilter();
+    ParseExpressionResult result = filter.parseExpressions(mockConfig, null);
+
+    assertThat(result.getExpressionPatterns().size(), equalTo(2));
+    assertThat(result.getExpressionPatterns().get(0).pattern(), equalTo(".*/health.*"));
+    assertThat(result.getExpressionPatterns().get(1).pattern(), equalTo(".*/actuator.*"));
+    assertThat(result.getRegularExpressions(), equalTo(""));
+  }
+
+  @Test
+  void testEmptyArrayHttpFilter() {
+    ConfigProperties mockConfig = mock();
+    when(mockConfig.getString(HttpEndpointFilter.LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX))
+        .thenReturn("[]");
+
+    HttpEndpointFilter filter = new HttpEndpointFilter();
+    ParseExpressionResult result = filter.parseExpressions(mockConfig, null);
+
+    assertThat(result.getExpressionPatterns().size(), equalTo(0));
+    assertThat(result.getRegularExpressions(), equalTo("[]"));
+  }
+
+  @Test
+  void testCustomHttpFilter() {
+    ConfigProperties mockConfig = mock();
+    when(mockConfig.getString(HttpEndpointFilter.LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX))
+        .thenReturn("[\".*/custom.*\"]");
+
+    HttpEndpointFilter filter = new HttpEndpointFilter();
+    ParseExpressionResult result = filter.parseExpressions(mockConfig, null);
+
+    assertThat(result.getExpressionPatterns().size(), equalTo(1));
+    assertThat(result.getExpressionPatterns().get(0).pattern(), equalTo(".*/custom.*"));
+    assertThat(result.getRegularExpressions(), equalTo("[\".*/custom.*\"]"));
+  }
+
+  @Test
+  void testInvalidJsonHttpFilter() {
+    ConfigProperties mockConfig = mock();
+    when(mockConfig.getString(HttpEndpointFilter.LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX))
+        .thenReturn("['.*\"my.*']");
+
+    HttpEndpointFilter filter = new HttpEndpointFilter();
+    ParseExpressionResult result = filter.parseExpressions(mockConfig, null);
+
+    assertThat(result.getExpressionPatterns().size(), equalTo(2));
+    assertThat(result.getExpressionPatterns().get(0).pattern(), equalTo(".*/health.*"));
+    assertThat(result.getExpressionPatterns().get(1).pattern(), equalTo(".*/actuator.*"));
+    assertThat(result.getRegularExpressions(), equalTo("['.*\"my.*']"));
+  }
+
+  @Test
+  void testInvalidRegExHttpFilter() {
+    ConfigProperties mockConfig = mock();
+    when(mockConfig.getString(HttpEndpointFilter.LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX))
+        .thenReturn("[\"(ad\"]");
+
+    HttpEndpointFilter filter = new HttpEndpointFilter();
+    ParseExpressionResult result = filter.parseExpressions(mockConfig, null);
+
+    assertThat(result.getExpressionPatterns().size(), equalTo(2));
+    assertThat(result.getExpressionPatterns().get(0).pattern(), equalTo(".*/health.*"));
+    assertThat(result.getExpressionPatterns().get(1).pattern(), equalTo(".*/actuator.*"));
+    assertThat(result.getRegularExpressions(), equalTo("[\"(ad\"]"));
+  }
+
+  @Test
+  void testInvalidJsonPlainStringFilter() {
+    ConfigProperties mockConfig = mock();
+    when(mockConfig.getString(HttpEndpointFilter.LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX))
+        .thenReturn("foo");
+
+    HttpEndpointFilter filter = new HttpEndpointFilter();
+    ParseExpressionResult result = filter.parseExpressions(mockConfig, null);
+
+    assertThat(result.getExpressionPatterns().size(), equalTo(2));
+    assertThat(result.getExpressionPatterns().get(0).pattern(), equalTo(".*/health.*"));
+    assertThat(result.getExpressionPatterns().get(1).pattern(), equalTo(".*/actuator.*"));
+    assertThat(result.getRegularExpressions(), equalTo("foo"));
+  }
+
+  @Test
+  void testInvalidJsonObjectFilter() {
+    ConfigProperties mockConfig = mock();
+    when(mockConfig.getString(HttpEndpointFilter.LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX))
+        .thenReturn("{\"foo\": \"bar\"}");
+
+    HttpEndpointFilter filter = new HttpEndpointFilter();
+    ParseExpressionResult result = filter.parseExpressions(mockConfig, null);
+
+    assertThat(result.getExpressionPatterns().size(), equalTo(2));
+    assertThat(result.getExpressionPatterns().get(0).pattern(), equalTo(".*/health.*"));
+    assertThat(result.getExpressionPatterns().get(1).pattern(), equalTo(".*/actuator.*"));
+    assertThat(result.getRegularExpressions(), equalTo("{\"foo\": \"bar\"}"));
+  }
+}

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/lumigo/javaagent/instrumentation/servlet/v3_0/BufferedReaderInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/lumigo/javaagent/instrumentation/servlet/v3_0/BufferedReaderInstrumentation.java
@@ -93,9 +93,7 @@ public class BufferedReaderInstrumentation implements TypeInstrumentation {
       }
 
       if (read == -1) {
-        System.out.println("read() BEFORE captureRequestBody()");
         bufferHolder.captureRequestBody();
-        System.out.println("read() AFTER captureRequestBody()");
       } else {
         bufferHolder.append(read);
       }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/lumigo/javaagent/instrumentation/servlet/v3_0/ServletInputStreamInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/lumigo/javaagent/instrumentation/servlet/v3_0/ServletInputStreamInstrumentation.java
@@ -121,9 +121,7 @@ public class ServletInputStreamInstrumentation implements TypeInstrumentation {
 
       if (read == -1) {
         // Buffer is complete
-        System.out.println("IS.read() BEFORE captureRequestBody()");
         bufferHolder.captureRequestBody();
-        System.out.println("IS.read() AFTER captureRequestBody()");
       } else {
         bufferHolder.append(read);
       }

--- a/smoke-tests/src/test/java/io/lumigo/javaagent/smoketest/EnvironmentVariableSmokeTest.java
+++ b/smoke-tests/src/test/java/io/lumigo/javaagent/smoketest/EnvironmentVariableSmokeTest.java
@@ -202,7 +202,7 @@ class EnvironmentVariableSmokeTest {
         (traceNodes) -> {
           assertTestResults(traceNodes, SCRUBBED_VALUE, SCRUBBED_VALUE, MY_VALUE);
 
-          assertThat(target.getLogs(), containsString("Failed to parse the masking regex:"));
+          assertThat(target.getLogs(), containsString("Failed to parse the regex:"));
         });
   }
 
@@ -223,7 +223,7 @@ class EnvironmentVariableSmokeTest {
         (traceNodes) -> {
           assertTestResults(traceNodes, SCRUBBED_VALUE, SCRUBBED_VALUE, MY_VALUE);
 
-          assertThat(target.getLogs(), containsString("Failed to parse the masking regex:"));
+          assertThat(target.getLogs(), containsString("Failed to parse the regex:"));
         });
   }
 

--- a/smoke-tests/src/test/java/io/lumigo/javaagent/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/io/lumigo/javaagent/smoketest/SpringBootSmokeTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.lumigo.javaagent.junitextensions.OkHttpClientExtension;
 import io.lumigo.javaagent.junitextensions.TestAppExtension;
@@ -36,6 +37,7 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.NoSuchElementException;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -49,7 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class SpringBootSmokeTest {
 
   @Test
-  public void testDefaultSettings(final TestAppExtension.TestApplication target) {
+  void testDefaultSettings(final TestAppExtension.TestApplication target) {
     final String logs = target.getLogs();
 
     /*
@@ -81,7 +83,7 @@ class SpringBootSmokeTest {
   }
 
   @Test
-  public void testInvalidSpanDump(
+  void testInvalidSpanDump(
       final @Configuration(env = {@EnvVar(key = "LUMIGO_DEBUG_SPANDUMP", value = "invalid")})
           TestAppExtension.TestApplication target) {
     final String logs = target.getLogs();
@@ -90,14 +92,49 @@ class SpringBootSmokeTest {
   }
 
   @Test
-  public void testSwitchOff(
+  void testSwitchOff(
       final @Configuration(env = {@EnvVar(key = "LUMIGO_SWITCH_OFF", value = "true")})
           TestAppExtension.TestApplication target) {
     assertThat(target.getLogs(), containsString("Lumigo OpenTelemetry Java distribution disabled"));
   }
 
   @Test
-  public void testSpanDump(final TestAppExtension.TestApplication target, final OkHttpClient client)
+  void testCustomHttpFilter(
+      final @Configuration(
+              env = {
+                @EnvVar(
+                    key = "LUMIGO_AUTO_FILTER_HTTP_ENDPOINTS_REGEX",
+                    value = "[\".*/greeting.*\", \".*/actuator.*\"]")
+              }) TestAppExtension.TestApplication target,
+      final OkHttpClient client)
+      throws IOException {
+    assertThat(
+        target.getLogs(),
+        containsString(
+            "sampler=RuleBasedRoutingSampler{rules=[SamplingRule{attributeKey=url.full, delegate=AlwaysOffSampler, pattern=.*/greeting.*}"));
+
+    final String url = String.format("http://localhost:%d/greeting", target.getMappedPort(8080));
+    final Request request = new Request.Builder().url(url).get().build();
+
+    try (final Response response = client.newCall(request).execute()) {
+      assertThat(response.body(), is(notNullValue()));
+      assertThat(response.code(), is(200));
+    }
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              List<SpanDumpEntry> entries = target.getSpanDump();
+              assertThat(entries.size(), is(0));
+
+              TypeSafeMatcher<SpanDumpEntry> hasSpanName = hasSpanName("GET /greeting");
+              assertThrows(NoSuchElementException.class, () -> findSpan(entries, hasSpanName));
+            });
+  }
+
+  @Test
+  void testSpanDump(final TestAppExtension.TestApplication target, final OkHttpClient client)
       throws IOException {
     assertThat(
         target.getLogs(),


### PR DESCRIPTION
Filtering can be altered by setting the `lumigo.auto.filter.http.endpoints.regex` environment variable to an array of regex expressions