### PR TITLE
feat: Limit payload collection for AWS SDK v2

### DIFF
--- a/bootstrap/src/main/java/io/lumigo/instrumentation/core/AbstractBufferHolder.java
+++ b/bootstrap/src/main/java/io/lumigo/instrumentation/core/AbstractBufferHolder.java
@@ -21,6 +21,8 @@ import io.opentelemetry.api.trace.Span;
 import java.io.UnsupportedEncodingException;
 
 public abstract class AbstractBufferHolder {
+  public static final int MAX_BUFFER_LENGTH = 2048;
+
   protected final Span span;
   protected final String charsetName;
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/lumigo/javaagent/instrumentation/awssdk/v2_2/PayloadBridge.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/lumigo/javaagent/instrumentation/awssdk/v2_2/PayloadBridge.java
@@ -37,6 +37,22 @@ public class PayloadBridge {
 
   private PayloadBridge() {}
 
+  public static int getRequestPayloadBufferSize(Context context) {
+    PayloadBridge bridge = context.get(CONTEXT_KEY);
+    if (bridge != null) {
+      return bridge.requestPayloadBufferLength;
+    }
+    return -1;
+  }
+
+  public static boolean isFirstRequestPayload(Context context) {
+    PayloadBridge bridge = context.get(CONTEXT_KEY);
+    if (bridge != null) {
+      return bridge.isFirstRequestPayload;
+    }
+    return true;
+  }
+
   public static void appendResponsePayload(
       Context context, byte[] buffer, int bodyStartPos, int length) {
     PayloadBridge bridge = context.get(CONTEXT_KEY);

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/lumigo/javaagent/instrumentation/awssdk/v2_2/SessionOutputBufferInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/lumigo/javaagent/instrumentation/awssdk/v2_2/SessionOutputBufferInstrumentation.java
@@ -17,6 +17,7 @@
  */
 package io.lumigo.javaagent.instrumentation.awssdk.v2_2;
 
+import static io.lumigo.instrumentation.core.AbstractBufferHolder.MAX_BUFFER_LENGTH;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static net.bytebuddy.matcher.ElementMatchers.*;
@@ -55,42 +56,44 @@ public class SessionOutputBufferInstrumentation implements TypeInstrumentation {
         @Advice.Argument(0) byte[] buffer,
         @Advice.Argument(1) int off,
         @Advice.Argument(2) int len) {
+      Context context = currentContext();
+      int capturedBuffer = PayloadBridge.getRequestPayloadBufferSize(context);
+      if (capturedBuffer == -1 || capturedBuffer >= MAX_BUFFER_LENGTH) {
+        // Skip capturing more than 2KB of data
+        return;
+      }
+
+      if (!PayloadBridge.isFirstRequestPayload(context)) {
+        // Skip checking for headers when we've already captured body content
+        PayloadBridge.appendRequestPayload(context, buffer, -1, len);
+        return;
+      }
+
       int bodyStartPos = -1;
+      int capturedLength = -1;
       // The HTTP body begins after the first two consecutive set of '\r\n' characters in the
       // request
-      // We scan then two-by-two to reduce iterations. The body may start on an odd or
-      // even character count, but this will be compensated by advancing i "just enough"
-      // to go to the next candidate pair of characters.
       for (int i = 0;
           // We check only if we have at least two characters left, otherwise there is not
           // enough data in the buffer to contain an HTTP body anyhow.
           i < len - 1;
-      // We manually increment the position in the loop, as increments could be by
-      // one or by two depending on what we find.
+          i++
       ) {
 
-        if ((char) buffer[i] != '\r') {
-          if ((char) buffer[i + 1] == '\r') {
-            // The first character is not '\r', but the second is, and we will check
-            // in the next iteration from there.
-            i += 1;
-          } else {
-            // Neither the next nor the following character are '\r', we can skip both
-            i += 2;
-          }
-        } else if ((char) buffer[i + 2] != '\r') {
-          // The first character is a '\r', but the character two positions further is not,
-          // so we likely found the beginning of the next header
-          i += 3;
-        } else if ((char) buffer[i + 1] == '\n' && (char) buffer[i + 3] == '\n') {
+        if (i - bodyStartPos >= MAX_BUFFER_LENGTH) {
+          capturedLength = i - bodyStartPos;
+          // Skip capturing more than 2KB of data
+          break;
+        }
+
+        if ((char) buffer[i] == '\r' && (char) buffer[i + 1] == '\n' && (char) buffer[i + 2] == '\r' && (char) buffer[i + 3] == '\n') {
           // We found the end of the headers segment :-)
           bodyStartPos = i + 4;
           break;
         }
       }
 
-      Context context = currentContext();
-      PayloadBridge.appendRequestPayload(context, buffer, bodyStartPos, len);
+      PayloadBridge.appendRequestPayload(context, buffer, bodyStartPos, capturedLength != -1 ? capturedLength : len);
     }
   }
 }


### PR DESCRIPTION
Ensure we're not capturing more than 2048 chars of payload data, as anything larger will be dropped by Lumigo's ingestion edge.