### PR TITLE
fix: Upgrade Testcontainers to 1.21.4 for Docker API 1.44 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ subprojects {
       autovalue                  : "1.10.1",
       junit                      : "5.11.3",
       mockito                    : "5.4.0",
-      testcontainers             : "1.17.6",
+      testcontainers             : "1.21.4",
       hamcrest                   : "2.2"
     ]
 


### PR DESCRIPTION
## Problem

GitHub Actions upgraded `ubuntu-latest` runners from Ubuntu 22.04 to Ubuntu 24.04 (between Feb 11-16, 2026), which requires Docker API 1.44+. 

## Solution

Upgrade Testcontainers from 1.17.6 to 1.21.4, which includes docker-java 3.4.2 with Docker API 1.44 support.